### PR TITLE
Update browser sync to support urls without extensions

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -73,7 +73,10 @@ task("startServer", () => {
     open: "local",
     port: 4000,
     server: {
-      baseDir: siteRoot
+      baseDir: siteRoot,
+      serveStaticOptions: {
+        extensions: ["html"]
+      }
     }
   });
 


### PR DESCRIPTION
Hey @taylorbryant!

Thanks for this project, it was really helpful in updating my old Jekyll site to use Tailwind.

I've found one issue, however. Visiting URLs without the `.html` extension was throwing 404, so this PR fixes that. 
